### PR TITLE
`KafkaProducer` with `sendAsync` method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-kafka-gsoc",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
     products: [
         .library(
             name: "SwiftKafka",

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -29,7 +29,7 @@ final class KafkaClient {
     /// The configuration object of the client
     private let config: KafkaConfig
     /// Handle for the C library's Kafka instance
-    private let kafkaHandle: OpaquePointer
+    let kafkaHandle: OpaquePointer
 
     /// Determines if client is a producer or a consumer
     enum `Type` {

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import struct Foundation.Data
+
+/// Messages that are received from the Kafka cluster.
+public struct KafkaConsumerMessage {
+    let topic: String
+    let partition: Int32
+    let key: Data?
+    let value: Data
+    let offset: Int64
+
+    // TODO: copy on write, does this even make sense as we read-only?
+    // TODO: deallocate rd_kafka_message_t on deinit
+
+    /// Initialize `KafkaConsumerMessage` from `rd_kafka_message_t` pointer.
+    init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
+        let rdKafkaMessage = messagePointer.pointee
+
+        guard rdKafkaMessage.err.rawValue == 0 else {
+            throw KafkaError(error: rdKafkaMessage.err)
+        }
+
+        guard let topic = String(validatingUTF8: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
+            throw KafkaError(description: "Topic name not UTF8 encoded")
+        }
+        self.topic = topic
+
+        self.partition = rdKafkaMessage.partition
+
+        if let keyPointer = rdKafkaMessage.key {
+            self.key = Data(
+                bytes: keyPointer.assumingMemoryBound(to: UInt8.self),
+                count: rdKafkaMessage.key_len
+            )
+        } else {
+            self.key = nil
+        }
+
+        guard let valuePointer = rdKafkaMessage.payload else {
+            throw KafkaError(description: "Message payload could not be read")
+        }
+
+        self.value = Data(
+            bytes: valuePointer.assumingMemoryBound(to: UInt8.self),
+            count: rdKafkaMessage.len
+        )
+
+        self.offset = Int64(rdKafkaMessage.offset)
+    }
+
+    /// Optional String representation of the message's key.
+    public var keyString: String? {
+        guard let key = self.key else {
+            return nil
+        }
+
+        return String(data: key, encoding: .utf8)
+    }
+
+    /// Optional String representation of the message's value.
+    public var valueString: String? {
+        return String(data: value, encoding: .utf8)
+    }
+}

--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -12,7 +12,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Crdkafka
+
 public struct KafkaError: Error {
     // Preliminary Implementation
+    public let rawValue: Int32
     public let description: String
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+        self.description = "" // TODO: error PR
+    }
+
+    init(description: String) {
+        self.rawValue = -1
+        self.description = description
+    }
+
+    init(error: rd_kafka_resp_err_t) {
+        self.rawValue = error.rawValue
+        self.description = String(cString: rd_kafka_err2str(error))
+    }
 }

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -17,15 +17,14 @@ import Logging
 
 /// Send messages to the Kafka cluster.
 public struct KafkaProducer {
-    // TODO: can we somehow share all the handles between multiple KafkaProducers?
-    // TODO: do we need a semaphore / actors for accessing topicHandles?
     private final class _Internal {
         let client: KafkaClient
-        var topicHandles: [String: OpaquePointer] = [:]
+        let topicHandles: KafkaTopicHandles
         let pollTask: Task<Void, Never>
 
         init(client: KafkaClient) {
             self.client = client
+            self.topicHandles = KafkaTopicHandles(kafkaHandle: self.client.kafkaHandle)
             self.pollTask = Task {
                 while !Task.isCancelled {
                     rd_kafka_poll(client.kafkaHandle, 0)
@@ -35,10 +34,13 @@ public struct KafkaProducer {
         }
 
         deinit {
-            // TODO: wait for outstanding messages using flush
-            // TODO: deallocate all entries of messageToCallback
-            for (_, topicHandle) in topicHandles {
-                rd_kafka_topic_destroy(topicHandle)
+            let kafkaHandle = client.kafkaHandle
+
+            // Wait 10 seconds for outstanding messages to be sent and callbacks to be called
+            rd_kafka_flush(kafkaHandle, 10000)
+
+            Task {
+                await KafkaProducerCallbacks.shared.deallocateCallbacks(for: kafkaHandle)
             }
 
             self.pollTask.cancel()
@@ -50,13 +52,6 @@ public struct KafkaProducer {
     let client: KafkaClient
 
     private var _internal: _Internal
-
-    // TODO: handle with actors? maybe even global actor
-    static var messageToCallback = [
-        OpaquePointer: [
-            UnsafeMutableRawPointer: (Result<KafkaConsumerMessage, KafkaError>) -> Void
-        ]
-    ]()
 
     /// Initialize a new `KafkaProducer`.
     /// - Parameter config: The ``KafkaConfig`` for configuring the `KafkaProducer`.
@@ -71,61 +66,58 @@ public struct KafkaProducer {
         self.topicConfig = topicConfig
         self.client = try KafkaClient(type: .producer, config: config, logger: logger)
         self._internal = .init(client: self.client)
-
-        // TODO: Not to happy about how this is managed / maybe actor?
-        KafkaProducer.messageToCallback[self.client.kafkaHandle] = [:]
-
-        // TODO: initial poll in setMessageCallback?
     }
 
     /// Send messages to the Kafka cluster asynchronously, aka "fire and forget".
     /// This function is non-blocking.
     /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
     /// - Parameter completionHandler: Closure that will be executed once the Kafka cluster has received the message.
-    mutating func sendAsync(
+    public func sendAsync(
         message: KafkaProducerMessage,
         completionHandler: ((Result<KafkaConsumerMessage, KafkaError>) -> Void)? = nil
     ) {
-        let topicHandle: OpaquePointer
-        if let handle = self._internal.topicHandles[message.topic] {
-            topicHandle = handle
-        } else {
-            topicHandle = rd_kafka_topic_new(
-                self.client.kafkaHandle,
-                message.topic,
-                self.topicConfig.pointer
+        Task {
+            let topicHandle = await self._internal.topicHandles.getTopicHandle(
+                topic: message.topic,
+                topicConfig: self.topicConfig
             )
-            self._internal.topicHandles[message.topic] = topicHandle
+
+            let keyBytes: [UInt8]?
+            if let key = message.key {
+                keyBytes = key.withUnsafeBytes { Array($0) }
+            } else {
+                keyBytes = nil
+            }
+
+            let idPointer = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 0)
+
+            let responseCode = message.value.withUnsafeBytes { valueBuffer in
+
+                return rd_kafka_produce(
+                    topicHandle,
+                    message.partition,
+                    RD_KAFKA_MSG_F_COPY,
+                    UnsafeMutableRawPointer(mutating: valueBuffer.baseAddress),
+                    valueBuffer.count,
+                    keyBytes,
+                    keyBytes?.count ?? 0,
+                    idPointer
+                )
+            }
+
+            guard responseCode == 0 else {
+                completionHandler?(.failure(KafkaError(rawValue: responseCode)))
+                return
+            }
+
+            if let completionHandler = completionHandler {
+                let kafkaHandle = self.client.kafkaHandle
+                await KafkaProducerCallbacks.shared.set(
+                    for: kafkaHandle,
+                    messageID: idPointer,
+                    callback: completionHandler
+                )
+            }
         }
-
-        let keyBytes: [UInt8]?
-        if let key = message.key {
-            keyBytes = key.withUnsafeBytes { Array($0) }
-        } else {
-            keyBytes = nil
-        }
-
-        let idPointer = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 0)
-
-        let responseCode = message.value.withUnsafeBytes { valueBuffer in
-
-            return rd_kafka_produce(
-                topicHandle,
-                message.partition,
-                RD_KAFKA_MSG_F_COPY,
-                UnsafeMutableRawPointer(mutating: valueBuffer.baseAddress),
-                valueBuffer.count,
-                keyBytes,
-                keyBytes?.count ?? 0,
-                idPointer
-            )
-        }
-
-        guard responseCode == 0 else {
-            completionHandler?(.failure(KafkaError(rawValue: responseCode)))
-            return
-        }
-
-        KafkaProducer.messageToCallback[self.client.kafkaHandle]?[idPointer] = completionHandler
     }
 }

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -15,17 +15,117 @@
 import Crdkafka
 import Logging
 
+/// Send messages to the Kafka cluster.
 public struct KafkaProducer {
-    let client: KafkaClient
-    let topicConfig: KafkaTopicConfig
+    // TODO: can we somehow share all the handles between multiple KafkaProducers?
+    // TODO: do we need a semaphore / actors for accessing topicHandles?
+    private final class _Internal {
+        let client: KafkaClient
+        var topicHandles: [String: OpaquePointer] = [:]
+        let pollTask: Task<Void, Never>
 
-    // Preliminary implementation
+        init(client: KafkaClient) {
+            self.client = client
+            self.pollTask = Task {
+                while !Task.isCancelled {
+                    rd_kafka_poll(client.kafkaHandle, 0)
+                    try? await Task.sleep(nanoseconds: 1_000_000)
+                }
+            }
+        }
+
+        deinit {
+            // TODO: wait for outstanding messages using flush
+            // TODO: deallocate all entries of messageToCallback
+            for (_, topicHandle) in topicHandles {
+                rd_kafka_topic_destroy(topicHandle)
+            }
+
+            self.pollTask.cancel()
+        }
+    }
+
+    let config: KafkaConfig
+    let topicConfig: KafkaTopicConfig
+    let client: KafkaClient
+
+    private var _internal: _Internal
+
+    // TODO: handle with actors? maybe even global actor
+    static var messageToCallback = [
+        OpaquePointer: [
+            UnsafeMutableRawPointer: (Result<KafkaConsumerMessage, KafkaError>) -> Void
+        ]
+    ]()
+
+    /// Initialize a new `KafkaProducer`.
+    /// - Parameter config: The ``KafkaConfig`` for configuring the `KafkaProducer`.
+    /// - Parameter topicConfig: The ``KafkaTopicConfig`` used for newly created topics.
+    /// - Parameter logger: A logger.
     public init(
         config: KafkaConfig = KafkaConfig(),
         topicConfig: KafkaTopicConfig = KafkaTopicConfig(),
         logger: Logger
     ) throws {
-        self.client = try KafkaClient(type: .producer, config: config, logger: logger)
+        self.config = config
         self.topicConfig = topicConfig
+        self.client = try KafkaClient(type: .producer, config: config, logger: logger)
+        self._internal = .init(client: self.client)
+
+        // TODO: Not to happy about how this is managed / maybe actor?
+        KafkaProducer.messageToCallback[self.client.kafkaHandle] = [:]
+
+        // TODO: initial poll in setMessageCallback?
+    }
+
+    /// Send messages to the Kafka cluster asynchronously, aka "fire and forget".
+    /// This function is non-blocking.
+    /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
+    /// - Parameter completionHandler: Closure that will be executed once the Kafka cluster has received the message.
+    mutating func sendAsync(
+        message: KafkaProducerMessage,
+        completionHandler: ((Result<KafkaConsumerMessage, KafkaError>) -> Void)? = nil
+    ) {
+        let topicHandle: OpaquePointer
+        if let handle = self._internal.topicHandles[message.topic] {
+            topicHandle = handle
+        } else {
+            topicHandle = rd_kafka_topic_new(
+                self.client.kafkaHandle,
+                message.topic,
+                self.topicConfig.pointer
+            )
+            self._internal.topicHandles[message.topic] = topicHandle
+        }
+
+        let keyBytes: [UInt8]?
+        if let key = message.key {
+            keyBytes = key.withUnsafeBytes { Array($0) }
+        } else {
+            keyBytes = nil
+        }
+
+        let idPointer = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 0)
+
+        let responseCode = message.value.withUnsafeBytes { valueBuffer in
+
+            return rd_kafka_produce(
+                topicHandle,
+                message.partition,
+                RD_KAFKA_MSG_F_COPY,
+                UnsafeMutableRawPointer(mutating: valueBuffer.baseAddress),
+                valueBuffer.count,
+                keyBytes,
+                keyBytes?.count ?? 0,
+                idPointer
+            )
+        }
+
+        guard responseCode == 0 else {
+            completionHandler?(.failure(KafkaError(rawValue: responseCode)))
+            return
+        }
+
+        KafkaProducer.messageToCallback[self.client.kafkaHandle]?[idPointer] = completionHandler
     }
 }

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import Logging
+
+public struct KafkaProducer {
+    let client: KafkaClient
+    let topicConfig: KafkaTopicConfig
+
+    // Preliminary implementation
+    public init(
+        config: KafkaConfig = KafkaConfig(),
+        topicConfig: KafkaTopicConfig = KafkaTopicConfig(),
+        logger: Logger
+    ) throws {
+        self.client = try KafkaClient(type: .producer, config: config, logger: logger)
+        self.topicConfig = topicConfig
+    }
+}

--- a/Sources/SwiftKafka/KafkaProducerCallbacks.swift
+++ b/Sources/SwiftKafka/KafkaProducerCallbacks.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Actor used for storing callback functions of sent messages.
+@globalActor
+actor KafkaProducerCallbacks {
+    static let shared = KafkaProducerCallbacks()
+
+    /// 2-dimensional Dictionary containing all callback closures `[kafkaHandle: [messageID: callback]]`.
+    private var callbacks = [
+        OpaquePointer: [
+            UnsafeMutableRawPointer: (Result<KafkaConsumerMessage, KafkaError>) -> Void
+        ]
+    ]()
+
+    // KafkaProducerCallback is a singleton and therefore not initializable
+    private init() {}
+
+    /// Get callback for a given Kafka handle and a message identifier.
+    /// - Parameter for: The `kafkaHandle` of the requesting `KafkaProducer`'s client.
+    /// - Parameter messageID: The message identifier.
+    /// - Returns: An optional callback for the given parameters.
+    func get(
+        for kafkaHandle: OpaquePointer,
+        messageID: UnsafeMutableRawPointer
+    ) -> ((Result<KafkaConsumerMessage, KafkaError>) -> Void)? {
+
+        let callback = self.callbacks[kafkaHandle]?[messageID]
+        if callback != nil {
+            self.callbacks[kafkaHandle]?[messageID] = nil
+        }
+        return callback
+    }
+
+    /// Set callback for a given Kafka handle and a message identifier.
+    /// - Parameter for: The `kafkaHandle` of the requesting `KafkaProducer`'s client.
+    /// - Parameter messageID: The message identifier.
+    /// - Parameter callback: Closure that is called once the message delivery report is received
+    func set(
+        for kafkaHandle: OpaquePointer,
+        messageID: UnsafeMutableRawPointer,
+        callback: @escaping (Result<KafkaConsumerMessage, KafkaError>) -> Void
+    ) {
+        if self.callbacks[kafkaHandle] == nil {
+            self.callbacks[kafkaHandle] = [:]
+        }
+
+        callbacks[kafkaHandle]?[messageID] = callback
+    }
+
+    /// Deallocate all message ID pointers and dictionary entries for a given Kafka handle
+    /// - Parameter for: The `kafkaHandle` of the requesting `KafkaProducer`'s client.
+    func deallocateCallbacks(for kafkaHandle: OpaquePointer) {
+        self.callbacks[kafkaHandle]?.forEach { (messageID, _) in
+            messageID.deallocate()
+            self.callbacks[kafkaHandle]?[messageID] = nil
+        }
+    }
+}

--- a/Sources/SwiftKafka/KafkaProducerMessage.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessage.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import Foundation
+
+/// Message that is sent by the `KafkaProducer`
+public struct KafkaProducerMessage {
+    let topic: String
+    let partition: Int32
+    let key: ContiguousBytes?
+    let value: ContiguousBytes
+
+    /// Create a new `KafkaProducerMessage` with any keys and values pair that conform to the `ContiguousBytes` protocol
+    /// - Parameter topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    /// - Parameter partition: The topic partition the message will be sent to. If not set explicitly, the partiotion will be assigned automatically.
+    /// - Parameter key: Used to guarantee that messages with the same key will be sent to the same partittion so that their order is preserved.
+    /// - Parameter value: The message body.
+    public init(
+        topic: String,
+        partition: Int32? = nil,
+        key: ContiguousBytes? = nil,
+        value: ContiguousBytes
+    ) {
+        self.topic = topic
+        self.key = key
+        self.value = value
+
+        if let partition = partition {
+            self.partition = partition
+        } else {
+            self.partition = RD_KAFKA_PARTITION_UA
+        }
+    }
+
+    /// Create a new `KafkaProducerMessage` with a `String` key and value
+    /// - Parameter topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    /// - Parameter partition: The topic partition the message will be sent to. If not set explicitly, the partiotion will be assigned automatically.
+    /// - Parameter key: Used to guarantee that messages with the same key will be sent to the same partittion so that their order is preserved.
+    /// - Parameter value: The message body.
+    public init(
+        topic: String,
+        partition: Int32? = nil,
+        key: String? = nil,
+        value: String
+    ) {
+        self.init(
+            topic: topic,
+            partition: partition,
+            key: key?.data(using: .utf8),
+            value: Data(value.utf8)
+        )
+    }
+}

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -37,7 +37,8 @@ public struct KafkaTopicConfig: Hashable, Equatable {
         }
 
         deinit {
-            rd_kafka_topic_conf_destroy(pointer)
+            // rd_kafka_topic_conf_destroy(pointer)
+            // https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#ab1dcba74a35e8f3bfe3270ff600581d8
         }
 
         func value(forKey key: String) -> String? {

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// When messages get published to a non-existent topic, a new topic is created using the `KafkaTopicConfig`
+/// configuration object (only works if server has `auto.create.topics.enable` property set).
+/// `KafkaTopicConfig` is a `struct` that points to a configuration in memory.
+/// Once a property of the `KafkaTopicConfig` is changed, a duplicate in-memory config is created using the
+/// copy-on-write mechanism.
+/// For more information on how to configure Kafka topics, see
+/// [all available configurations](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties).
+public struct KafkaTopicConfig: Hashable, Equatable {
+    private final class _Internal: Hashable, Equatable {
+        /// Pointer to the `rd_kafka_topic_conf_t` object managed by `librdkafka`
+        private(set) var pointer: OpaquePointer
+
+        /// Initialize internal `KafkaTopicConfig` object with default configuration
+        init() {
+            self.pointer = rd_kafka_topic_conf_new()
+        }
+
+        /// Initialize internal `KafkaTopicConfig` object through a given `rd_kafka_topic_conf_t` pointer
+        init(pointer: OpaquePointer) {
+            self.pointer = pointer
+        }
+
+        deinit {
+            rd_kafka_topic_conf_destroy(pointer)
+        }
+
+        func value(forKey key: String) -> String? {
+            let value = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
+            defer { value.deallocate() }
+
+            var valueSize = KafkaClient.stringSize
+            let configResult = rd_kafka_topic_conf_get(
+                pointer,
+                key,
+                value,
+                &valueSize
+            )
+
+            if configResult == RD_KAFKA_CONF_OK {
+                return String(cString: value)
+            }
+            return nil
+        }
+
+        func set(_ value: String, forKey key: String) throws {
+            let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
+            defer { errorChars.deallocate() }
+
+            let configResult = rd_kafka_topic_conf_set(
+                pointer,
+                key,
+                value,
+                errorChars,
+                KafkaClient.stringSize
+            )
+
+            if configResult != RD_KAFKA_CONF_OK {
+                let errorString = String(cString: errorChars)
+                throw KafkaError(description: errorString)
+            }
+        }
+
+        func createDuplicate() -> _Internal {
+            let duplicatePointer: OpaquePointer = rd_kafka_topic_conf_dup(self.pointer)
+            return .init(pointer: duplicatePointer)
+        }
+
+        // MARK: Hashable
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(self.pointer)
+        }
+
+        // MARK: Equatable
+
+        static func == (lhs: _Internal, rhs: _Internal) -> Bool {
+            return lhs.pointer == rhs.pointer
+        }
+    }
+
+    private var _internal: _Internal
+
+    public init() {
+        self._internal = .init()
+    }
+
+    var pointer: OpaquePointer {
+        return self._internal.pointer
+    }
+
+    /// Retrieve value of topic configuration property for `key`
+    public func value(forKey key: String) -> String? {
+        return self._internal.value(forKey: key)
+    }
+
+    /// Set topic configuration `value` for `key`
+    public mutating func set(_ value: String, forKey key: String) throws {
+        // Copy-on-write mechanism
+        if !isKnownUniquelyReferenced(&(self._internal)) {
+            self._internal = self._internal.createDuplicate()
+        }
+
+        try self._internal.set(value, forKey: key)
+    }
+}

--- a/Sources/SwiftKafka/KafkaTopicHandles.swift
+++ b/Sources/SwiftKafka/KafkaTopicHandles.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// Actor that  contains and manages all Kafka topic handles of a producer.
+actor KafkaTopicHandles {
+
+    private let kafkaHandle: OpaquePointer
+    private var topicHandleCache: [String: OpaquePointer]
+
+    init(kafkaHandle: OpaquePointer) {
+        self.kafkaHandle = kafkaHandle
+        self.topicHandleCache = [:]
+    }
+
+    deinit {
+        for (_, topicHandle) in self.topicHandleCache {
+            rd_kafka_topic_destroy(topicHandle)
+        }
+    }
+
+    /// Get topic handle for a given topic name.
+    /// Creates a new topic handle if no matching handle could be found in cache.
+    /// - Parameter topic: The name of the Kafka topic.
+    /// - Parameter topicConfig: The ``KafkaTopicConfig`` used for newly created topics.
+    func getTopicHandle(
+        topic: String,
+        topicConfig: KafkaTopicConfig = KafkaTopicConfig()
+    ) -> OpaquePointer? {
+
+        if let handle = self.topicHandleCache[topic] {
+            return handle
+        } else {
+            let newHandle = rd_kafka_topic_new(
+                self.kafkaHandle,
+                topic,
+                topicConfig.pointer
+            )
+            if newHandle != nil {
+                self.topicHandleCache[topic] = newHandle
+            }
+            return newHandle
+        }
+    }
+}

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SwiftKafka
+import XCTest
+
+final class KafkaProducerTests: XCTestCase {
+    // Read environment variables to get information about the test Kafka server
+    let kafkaHost = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
+    let kafkaPort = ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092"
+
+    // For testing locally on Mac, do the following:
+    // 1. Install Kafka and Zookeeper using homebrew
+    // https://medium.com/@Ankitthakur/apache-kafka-installation-on-mac-using-homebrew-a367cdefd273
+    // 2. Run the following command
+    // zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties & kafka-server-start /usr/local/etc/kafka/server.properties
+    func testSendAsync() throws {
+        let bootstrapServer = "\(kafkaHost):\(kafkaPort)"
+
+        var config = KafkaConfig()
+        try config.set(bootstrapServer, forKey: "bootstrap.servers")
+        try config.set("v4", forKey: "broker.address.family")
+
+        // TODO: implement producer in a way that send is not mutating so that we can use let here
+        var producer = try KafkaProducer(config: config, logger: .kafkaTest)
+
+        let expectedTopic = "test-topic"
+        let expectedValue = "Hello, World!"
+        let message = KafkaProducerMessage(
+            topic: expectedTopic,
+            value: expectedValue
+        )
+
+        let expectation = expectation(description: "Send complete")
+
+        producer.sendAsync(message: message) { result in
+            expectation.fulfill()
+
+            switch result {
+            case .success(let receivedMessage):
+                XCTAssertEqual(expectedTopic, receivedMessage.topic)
+                XCTAssertEqual(expectedValue, receivedMessage.valueString)
+            case .failure:
+                XCTFail("Sending message was unsuccessful")
+            }
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+}

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -19,6 +19,21 @@ final class KafkaProducerTests: XCTestCase {
     // Read environment variables to get information about the test Kafka server
     let kafkaHost = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
     let kafkaPort = ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092"
+    var bootstrapServer: String!
+    var config: KafkaConfig!
+
+    override func setUpWithError() throws {
+        self.bootstrapServer = "\(self.kafkaHost):\(self.kafkaPort)"
+
+        self.config = KafkaConfig()
+        try self.config.set(self.bootstrapServer, forKey: "bootstrap.servers")
+        try self.config.set("v4", forKey: "broker.address.family")
+    }
+
+    override func tearDownWithError() throws {
+        self.bootstrapServer = nil
+        self.config = nil
+    }
 
     // For testing locally on Mac, do the following:
     // 1. Install Kafka and Zookeeper using homebrew
@@ -26,14 +41,7 @@ final class KafkaProducerTests: XCTestCase {
     // 2. Run the following command
     // zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties & kafka-server-start /usr/local/etc/kafka/server.properties
     func testSendAsync() throws {
-        let bootstrapServer = "\(kafkaHost):\(kafkaPort)"
-
-        var config = KafkaConfig()
-        try config.set(bootstrapServer, forKey: "bootstrap.servers")
-        try config.set("v4", forKey: "broker.address.family")
-
-        // TODO: implement producer in a way that send is not mutating so that we can use let here
-        var producer = try KafkaProducer(config: config, logger: .kafkaTest)
+        let producer = try KafkaProducer(config: config, logger: .kafkaTest)
 
         let expectedTopic = "test-topic"
         let expectedValue = "Hello, World!"
@@ -58,4 +66,6 @@ final class KafkaProducerTests: XCTestCase {
 
         waitForExpectations(timeout: 2)
     }
+
+    // TODO: test concurrent send async
 }

--- a/Tests/SwiftKafkaTests/KafkaTopicConfigTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaTopicConfigTests.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SwiftKafka
+import XCTest
+
+final class KafkaTopicConfigTests: XCTestCase {
+    func testSettingCorrectValueWorks() throws {
+        var config = KafkaTopicConfig()
+
+        try config.set("gzip", forKey: "compression.type")
+
+        XCTAssertEqual("gzip", config.value(forKey: "compression.type"))
+    }
+
+    func testSettingWrongKeyFails() {
+        var config = KafkaTopicConfig()
+
+        XCTAssertThrowsError(try config.set("gzip", forKey: "not.a.valid.key"))
+    }
+
+    func testSettingWrongValueFails() {
+        var config = KafkaTopicConfig()
+
+        XCTAssertThrowsError(try config.set("not_a_compression_type", forKey: "compression.type"))
+    }
+
+    func testGetterHasNoSideEffects() {
+        let configA = KafkaTopicConfig()
+        let configB = configA
+
+        _ = configA.value(forKey: "compression.type")
+        _ = configB.value(forKey: "compression.type")
+
+        XCTAssertTrue(configA == configB)
+    }
+
+    func testCopyOnWriteWorks() throws {
+        var configA = KafkaTopicConfig()
+        let configB = configA
+        let configC = configA
+
+        // Check if all configs have the default value set
+        [configA, configB, configC].forEach {
+            XCTAssertEqual("inherit", $0.value(forKey: "compression.type"))
+        }
+
+        try configA.set("gzip", forKey: "compression.type")
+
+        XCTAssertEqual("gzip", configA.value(forKey: "compression.type"))
+        XCTAssertEqual("inherit", configB.value(forKey: "compression.type"))
+        XCTAssertEqual("inherit", configC.value(forKey: "compression.type"))
+        XCTAssertNotEqual(configA, configB)
+        XCTAssertNotEqual(configA, configC)
+        XCTAssertEqual(configB, configC)
+    }
+}

--- a/Tests/SwiftKafkaTests/Utilities.swift
+++ b/Tests/SwiftKafkaTests/Utilities.swift
@@ -12,7 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SwiftKafka
-import XCTest
+import Logging
 
-final class SwiftKafkaTests: XCTestCase {}
+extension Logger {
+    static var kafkaTest: Logger {
+        var logger = Logger(label: "kafka.test")
+        logger.logLevel = .info
+        return logger
+    }
+}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,30 @@
 # Usage: docker-compose -f docker/docker-compose.yaml run swift-kafka-gsoc
 version: "3.9"
 services:
+
+  zookeeper:
+    image: ubuntu/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: ubuntu/kafka
+    container_name: kafka_broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      ZOOKEEPER_HOST: zookeeper
+      ZOOKEEPER_PORT: 2181
+
   swift-kafka-gsoc:
+    depends_on:
+      - kafka
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    environment:
+      KAFKA_HOST: kafka
+      KAFKA_PORT: 9092


### PR DESCRIPTION
## Motivation

Enable users to send messages in a non-blocking way with an optional callback.

## Modifications

* specified minimum OS versions in `Package.swift` to support new Swift
  concurrency
* made it possible to test the KafkaProducer inside of Docker
* `KafkaProducerMessage`
* `KafkaConsumerMessage`
* `KafkaProducer `with sendAsync method
* initialization of `KafkaError `from `rd_kafka_resp_err_t`